### PR TITLE
Update orthography.ts

### DIFF
--- a/src/constants/orthography.ts
+++ b/src/constants/orthography.ts
@@ -1,57 +1,61 @@
 import { CONFIG } from './config'
 
-export const ORTHOGRAPHY = [
-’a’,
-’aa’,
-’aw’,
-’aaw’,
-’ay’,
-’aay’,
-’ch’,
-"ch’",
-’h’,
-’i’,
-’ii’,
-’iw’,
-’iiw’,
-’ɨ’,
-’k’,
-"k’",
-’kw’,
-"kw’",
-’ḵ’,
-"ḵ’",
-’ḵw’,
-"kw’",
-’l’,
-’ɬ’,
-’m’,
-’n’,
-’p’,
-"p’",
-’s’,
-’sh’,
-’t’,
-"t’",
-’tɬ’,
-"tɬ’",
-’ts’,
-"ts’",
-’u’,
-’uu’,
-’uy’,
-’uuy’,
-’w’,
-’x’,
-’xw’,
-’x̱’,
-’x̱w’
-’y’
-
+export const WORDS = [
+'mɨtaat',
+'pax̱aat',
+'mɨx̱ɨsh',
+'mɨkɨɬ',
+'timash',
+'lataam',
+'patat',
+"tɬ'piip",
+'kakya',
+'watim',
+'ɨwinsh',
+'aswan',
+'xaslu',
+'maytski',
+'pachway',
+'kwlaawit',
+'shatay',
+'taymun',
+'tkwsay',
+'aykawaas',
+'tamam',
+"kw'aɬa",
+'ɨshchɨt',
+'waawk’a',
+'tiskay',
+'kalux̱',
+'anahúy',
+'lakas',
+'likúuk',
+'yaamash',
+'timash',
+'tiinma',
+'chawtun',
+'mɨnan',
+'mɨnik',
+'aytalu',
+'x̱alish',
+'tsxwiili',
+'watam',
+'núsux̱',
+'latit',
+'ḵ’ax̱nu',
 ]
 
 if (CONFIG.normalization) {
-  ORTHOGRAPHY.forEach(
-    (val, i) => (ORTHOGRAPHY[i] = val.normalize(CONFIG.normalization))
-  )
+  WORDS.forEach((val, i) => (WORDS[i] = val.normalize(CONFIG.normalization)))
+}
+
+function shuffle(array: any[]) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[array[i], array[j]] = [array[j], array[i]]
+  }
+}
+
+if (CONFIG.shuffle) {
+  shuffle(WORDS)
 }


### PR DESCRIPTION
Hey @kelivermore, I noticed that many of your characters here were wrapped in a ’ which looks similar but is very different from ' 

You must use ' so I've changed these (and added a missing comma at the end), and it works, but after running the tests there are still the following issues:

For these words: ḵ’ax̱nu and waawk’a you have to change the apostrophe as well to ' (or you have to change the character in the orthography to the ’ - the main point is they have to be the same between your wordlist and orthography).

For these words: núsux̱ , likúuk and anahúy they all have a ú character that is not in your orthography. Either you have to add ú to your orthography or change the ú to u

These words are not 5 letters long: 

+   Array [
    +     "tɬ'",
    +     "p",
    +     "ii",
    +     "p",
    +   ],
    +   Array [
    +     "sh",
    +     "a",
    +     "t",
    +     "ay",
    +   ],
    +   Array [
    +     "t",
    +     "kw",
    +     "s",
    +     "ay",
    +   ],
    +   Array [
    +     "kw'",
    +     "a",
    +     "ɬ",
    +     "a",
    +   ],
    +   Array [
    +     "a",
    +     "n",
    +     "a",
    +     "h",
    +     "ú",
    +     "y",
    +   ],
    +   Array [
    +     "l",
    +     "i",
    +     "k",
    +     "ú",
    +     "u",
    +     "k",
    +   ],
    +   Array [
    +     "ḵ",
    +     "’",
    +     "a",
    +     "x̱",
    +     "n",
    +     "u",
    +   ],
    + ]

You can see the results of these tests by following the instructions under the "testing" section of the blog article: https://blog.mothertongues.org/wordle

Congrats for getting started on this! I hope this is helpful.